### PR TITLE
Fix for build errors related to `intptr_t` from `<cstdint>`

### DIFF
--- a/src/pointers-cpp.cc
+++ b/src/pointers-cpp.cc
@@ -1,6 +1,7 @@
 
 #include <string>
 #include <cstring>
+#include <cstdint>
 
 extern "C" void intptr_as_string(intptr_t ptr_int, char* buf) {
   std::string ptr_str = std::to_string(ptr_int);


### PR DESCRIPTION
I got the below errors when trying to build {narrow}

Following the compilation note (`intptr_t` is defined in header `<cstdint>`) I added the include statement for cstdint and had no further issue with installation.

```sh
> remotes::install_github("paleolimbot/narrow")
Downloading GitHub repo paleolimbot/narrow@HEAD
── R CMD build ───────────────────────────────────────────────────────────────────────────────────────────────
✔  checking for file ‘/tmp/Rtmp8FrHqH/remotese4c22457e047/paleolimbot-narrow-3572fb5/DESCRIPTION’ ...
─  preparing ‘narrow’:
✔  checking DESCRIPTION meta-information ...
─  cleaning src
─  checking for LF line-endings in source and make files and shell scripts
─  checking for empty or unneeded directories
   Removed empty directory ‘narrow/vignettes’
   Omitted ‘LazyData’ from DESCRIPTION
─  building ‘narrow_0.0.0.9000.tar.gz’
   
Installing package into ‘/home/andrew/R/x86_64-pc-linux-gnu-library/4.3’
(as ‘lib’ is unspecified)
* installing *source* package ‘narrow’ ...
** using staged installation
** libs
using C compiler: ‘gcc (GCC) 13.2.1 20230801’
using C++ compiler: ‘g++ (GCC) 13.2.1 20230801’
gcc -I"/usr/include/R/" -DNDEBUG   -I/usr/local/include    -fpic  -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -g -ffile-prefix-map=/build/r/src=/usr/src/debug/r -flto=auto -ffat-lto-objects  -c array-data.c -o array-data.o
gcc -I"/usr/include/R/" -DNDEBUG   -I/usr/local/include    -fpic  -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -g -ffile-prefix-map=/build/r/src=/usr/src/debug/r -flto=auto -ffat-lto-objects  -c array-stream-carrow-array.c -o array-stream-carrow-array.o
gcc -I"/usr/include/R/" -DNDEBUG   -I/usr/local/include    -fpic  -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -g -ffile-prefix-map=/build/r/src=/usr/src/debug/r -flto=auto -ffat-lto-objects  -c array-stream-function.c -o array-stream-function.o
gcc -I"/usr/include/R/" -DNDEBUG   -I/usr/local/include    -fpic  -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -g -ffile-prefix-map=/build/r/src=/usr/src/debug/r -flto=auto -ffat-lto-objects  -c array-stream-wrapper.c -o array-stream-wrapper.o
gcc -I"/usr/include/R/" -DNDEBUG   -I/usr/local/include    -fpic  -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -g -ffile-prefix-map=/build/r/src=/usr/src/debug/r -flto=auto -ffat-lto-objects  -c array-stream.c -o array-stream.o
gcc -I"/usr/include/R/" -DNDEBUG   -I/usr/local/include    -fpic  -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -g -ffile-prefix-map=/build/r/src=/usr/src/debug/r -flto=auto -ffat-lto-objects  -c array.c -o array.o
gcc -I"/usr/include/R/" -DNDEBUG   -I/usr/local/include    -fpic  -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -g -ffile-prefix-map=/build/r/src=/usr/src/debug/r -flto=auto -ffat-lto-objects  -c bitmask.c -o bitmask.o
gcc -I"/usr/include/R/" -DNDEBUG   -I/usr/local/include    -fpic  -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -g -ffile-prefix-map=/build/r/src=/usr/src/debug/r -flto=auto -ffat-lto-objects  -c cast-from-array.c -o cast-from-array.o
gcc -I"/usr/include/R/" -DNDEBUG   -I/usr/local/include    -fpic  -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -g -ffile-prefix-map=/build/r/src=/usr/src/debug/r -flto=auto -ffat-lto-objects  -c cast-to-array.c -o cast-to-array.o
gcc -I"/usr/include/R/" -DNDEBUG   -I/usr/local/include    -fpic  -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -g -ffile-prefix-map=/build/r/src=/usr/src/debug/r -flto=auto -ffat-lto-objects  -c copy.c -o copy.o
gcc -I"/usr/include/R/" -DNDEBUG   -I/usr/local/include    -fpic  -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -g -ffile-prefix-map=/build/r/src=/usr/src/debug/r -flto=auto -ffat-lto-objects  -c init.c -o init.o
gcc -I"/usr/include/R/" -DNDEBUG   -I/usr/local/include    -fpic  -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -g -ffile-prefix-map=/build/r/src=/usr/src/debug/r -flto=auto -ffat-lto-objects  -c int64.c -o int64.o
g++ -std=gnu++17 -I"/usr/include/R/" -DNDEBUG   -I/usr/local/include    -fpic  -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -Wp,-D_GLIBCXX_ASSERTIONS -g -ffile-prefix-map=/build/r/src=/usr/src/debug/r -flto=auto -ffat-lto-objects  -c narrow-cpp-impl.cc -o narrow-cpp-impl.o
gcc -I"/usr/include/R/" -DNDEBUG   -I/usr/local/include    -fpic  -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -g -ffile-prefix-map=/build/r/src=/usr/src/debug/r -flto=auto -ffat-lto-objects  -c narrow-impl.c -o narrow-impl.o
g++ -std=gnu++17 -I"/usr/include/R/" -DNDEBUG   -I/usr/local/include    -fpic  -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -Wp,-D_GLIBCXX_ASSERTIONS -g -ffile-prefix-map=/build/r/src=/usr/src/debug/r -flto=auto -ffat-lto-objects  -c pointers-cpp.cc -o pointers-cpp.o
pointers-cpp.cc:5:17: error: variable or field ‘intptr_as_string’ declared void
    5 | extern "C" void intptr_as_string(intptr_t ptr_int, char* buf) {
      |                 ^~~~~~~~~~~~~~~~
pointers-cpp.cc:5:34: error: ‘intptr_t’ was not declared in this scope
    5 | extern "C" void intptr_as_string(intptr_t ptr_int, char* buf) {
      |                                  ^~~~~~~~
pointers-cpp.cc:4:1: note: ‘intptr_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
    3 | #include <cstring>
  +++ |+#include <cstdint>
    4 | 
pointers-cpp.cc:5:52: error: expected primary-expression before ‘char’
    5 | extern "C" void intptr_as_string(intptr_t ptr_int, char* buf) {
      |                                                    ^~~~
make: *** [/usr/lib64/R/etc/Makeconf:198: pointers-cpp.o] Error 1
ERROR: compilation failed for package ‘narrow’
* removing ‘/home/andrew/R/x86_64-pc-linux-gnu-library/4.3/narrow’
Warning message:
In i.p(...) :
  installation of package ‘/tmp/Rtmp8FrHqH/filee4c27f1a7548/narrow_0.0.0.9000.tar.gz’ had non-zero exit status
```